### PR TITLE
Update xgboost_direct_marketing_sagemaker.ipynb to fix issues due to pandas library default updates

### DIFF
--- a/xgboost_direct_marketing_sagemaker.ipynb
+++ b/xgboost_direct_marketing_sagemaker.ipynb
@@ -283,7 +283,7 @@
    "outputs": [],
    "source": [
     "# cell 08\n",
-    "print(data.corr())\n",
+    "print(data.corr(numeric_only=True))\n",
     "pd.plotting.scatter_matrix(data, figsize=(12, 12))\n",
     "plt.show()"
    ]
@@ -338,7 +338,7 @@
    "outputs": [],
    "source": [
     "# cell 10\n",
-    "model_data = pd.get_dummies(data)                                                                  # Convert categorical variables to sets of indicators"
+    "model_data = pd.get_dummies(data, dtype=float)                                                                  # Convert categorical variables to sets of indicators"
    ]
   },
   {


### PR DESCRIPTION
Updating the corr method to add numric only field and also the get_dummies was outputing True/False instead of 0/1
This would fix the below issues

https://github.com/aws-samples/amazon-sagemaker-immersion-day/issues/81
https://github.com/aws-samples/amazon-sagemaker-immersion-day/issues/82